### PR TITLE
HRM 2 - Add TC for Login fail with incorrect credentials

### DIFF
--- a/tests/Login.spec.ts
+++ b/tests/Login.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "../fixtures/baseFixtures.ts";
+
+test("HRM 2 - Login with incorrect credentials", async ({ page, loginPage }) => {
+  await page.goto("/"); // Uses the baseURL from playwright.config.ts
+  await page.waitForLoadState("domcontentloaded");
+
+  await loginPage.login("Test", "test123");
+  await expect(page.getByText("Invalid credentials")).toBeVisible();
+});


### PR DESCRIPTION
## Summary:
- Add script for Login with incorrect credentials.
- Assert that error message: "Invalid credentials" is visible

## Steps:
1. Run `npx playwright test tests/Login.specs.ts`
2. Expected Result: Test pass, and the UI displays error message "Invalid credentials" 